### PR TITLE
persist PlanSummary and token usage heuristic for `--from-session`

### DIFF
--- a/docs/SPEC_PLAN_FROM_SESSION.md
+++ b/docs/SPEC_PLAN_FROM_SESSION.md
@@ -9,14 +9,15 @@ Inputs
 - `--include-tools` (optional) — include tool messages in summarization
 
 Output
-- On success (JSON): `plan.create.fromSession.v1` object containing at minimum:
+- On success (JSON): `plan.create.fromSession.v1` object containing:
   - `schema`: "plan.create.fromSession.v1"
   - `planId`: created plan id
   - `goal`: inferred short goal string
   - `candidateFiles`: array of file path hints (may be empty)
   - `messageSampleCount`: number of messages used
   - `truncated`: boolean
-  - `rationale`: optional short explanation
+  - `rationale`: optional short explanation (currently embedded only in persisted PlanSummary, may be added to JSON later)
+  - `tokenUsageApprox`: object `{ sampleChars, approxTokens }` (heuristic: (goal.Length + rationale.Length + Σ(filePath.Length+1)) / 4)
 
 Failure Modes
 - No session found: emit error object in JSON with code `SessionNotFound` and human error when not `--json`.
@@ -25,6 +26,7 @@ Failure Modes
 Behavior Notes
 - CandidateFiles are only hints (not staged or modified); they are expected to help the developer refine the plan.
 - The summarizer is deterministic and uses regex/file hint extraction; no network calls in Phase 1.
+- The persisted plan record now includes a `summary` object (PlanSummary) storing: source ("session"), goal, candidateFiles, rationale, usedMessages, totalMessages, truncated, tokenUsage (sampleChars, approxTokens). Legacy plan records without `summary` remain valid.
 
 Schema Versioning
 - Add new schema `plan.create.fromSession.v1`. Do not change existing `plan.create.v1`.

--- a/src/CodePunk.Console/Stores/IPlanFileStore.cs
+++ b/src/CodePunk.Console/Stores/IPlanFileStore.cs
@@ -32,4 +32,23 @@ public class PlanRecord
 {
     public PlanDefinition Definition { get; set; } = new();
     public List<PlanFileChange> Files { get; set; } = new();
+    public PlanSummary? Summary { get; set; }
+}
+
+public class PlanSummary
+{
+    public string Source { get; set; } = string.Empty; // e.g. "session"
+    public string Goal { get; set; } = string.Empty;
+    public List<string> CandidateFiles { get; set; } = new();
+    public string Rationale { get; set; } = string.Empty;
+    public int UsedMessages { get; set; }
+    public int TotalMessages { get; set; }
+    public bool Truncated { get; set; }
+    public TokenUsageApprox? TokenUsage { get; set; }
+}
+
+public class TokenUsageApprox
+{
+    public int SampleChars { get; set; }
+    public int ApproxTokens { get; set; }
 }

--- a/tests/CodePunk.Console.Tests/Commands/PlanBackwardCompatTests.cs
+++ b/tests/CodePunk.Console.Tests/Commands/PlanBackwardCompatTests.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+using Xunit;
+using System.IO;
+using System.Threading.Tasks;
+using CodePunk.Console.Stores;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using CodePunk.Console.Commands;
+using Spectre.Console;
+using Spectre.Console.Testing;
+using CodePunk.Console.Configuration;
+using CodePunk.Infrastructure.Configuration;
+
+namespace CodePunk.Console.Tests.Commands;
+
+public class PlanBackwardCompatTests
+{
+    [Fact]
+    public async Task Plan_Load_OldFormat_Without_Summary_Succeeds()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), "codepunk-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CODEPUNK_CONFIG_HOME", tmp);
+        Directory.CreateDirectory(tmp);
+        var plansDir = Path.Combine(tmp, "plans");
+        Directory.CreateDirectory(plansDir);
+        // craft an old style plan file (no Summary property)
+        var planId = "20240101010101-legacy";
+        var legacyJson = "{" +
+            "\n  \"Definition\": {\n    \"Id\": \"" + planId + "\",\n    \"Goal\": \"Legacy goal\",\n    \"CreatedUtc\": \"2024-01-01T01:01:01Z\"\n  }," +
+            "\n  \"Files\": []\n}";
+        await File.WriteAllTextAsync(Path.Combine(plansDir, planId + ".json"), legacyJson);
+
+        var testConsole = new TestConsole();
+        testConsole.Profile.Width = 5000;
+        var builder = Host.CreateApplicationBuilder(Array.Empty<string>());
+        builder.Services.AddCodePunkServices(builder.Configuration);
+        builder.Services.AddCodePunkConsole();
+        builder.Services.AddSingleton<IAnsiConsole>(sp => testConsole);
+        var host = builder.Build();
+        var store = host.Services.GetRequiredService<IPlanFileStore>();
+
+        try
+        {
+            var rec = await store.GetAsync(planId);
+            Assert.NotNull(rec);
+            Assert.Equal(planId, rec!.Definition.Id);
+            Assert.Equal("Legacy goal", rec.Definition.Goal);
+            Assert.Null(rec.Summary); // backward compat: Summary absent => null
+        }
+        finally { try { Directory.Delete(tmp, true); } catch { } }
+    }
+}

--- a/tests/CodePunk.Console.Tests/Commands/PlanBackwardCompatibilityTests.cs
+++ b/tests/CodePunk.Console.Tests/Commands/PlanBackwardCompatibilityTests.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Spectre.Console;
+using Spectre.Console.Testing;
+using Xunit;
+using CodePunk.Console.Configuration;
+using CodePunk.Infrastructure.Configuration;
+using CodePunk.Console.Stores;
+
+namespace CodePunk.Console.Tests.Commands;
+
+public class PlanBackwardCompatibilityTests
+{
+    [Fact]
+    public async Task Plan_Without_Summary_Field_Deserializes_With_Null_Summary()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), "codepunk-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CODEPUNK_CONFIG_HOME", tmp);
+        Directory.CreateDirectory(tmp);
+        try
+        {
+            var builder = Host.CreateApplicationBuilder(Array.Empty<string>());
+            builder.Services.AddCodePunkServices(builder.Configuration);
+            builder.Services.AddCodePunkConsole();
+            var testConsole = new TestConsole();
+            builder.Services.AddSingleton<IAnsiConsole>(sp => testConsole);
+            var host = builder.Build();
+            var store = host.Services.GetRequiredService<IPlanFileStore>();
+
+            var id = await store.CreateAsync("Legacy goal");
+            // Overwrite the stored json to mimic legacy file (remove Summary property entirely)
+            var planPath = Path.Combine(tmp, "plans", id + ".json");
+            var json = await File.ReadAllTextAsync(planPath);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            // root has Definition and Files; ensure we produce object without Summary
+            var legacy = new
+            {
+                Definition = JsonSerializer.Deserialize<object>(root.GetProperty("Definition").GetRawText()),
+                Files = new object[0]
+            };
+            var legacyJson = JsonSerializer.Serialize(legacy, new JsonSerializerOptions { WriteIndented = true });
+            await File.WriteAllTextAsync(planPath, legacyJson);
+
+            var rec = await store.GetAsync(id);
+            Assert.NotNull(rec);
+            Assert.Null(rec!.Summary); // Should be null, not throw
+        }
+        finally
+        {
+            try { Directory.Delete(tmp, true); } catch { }
+        }
+    }
+}

--- a/tests/CodePunk.Console.Tests/Commands/PlanCreateFromSessionTests.cs
+++ b/tests/CodePunk.Console.Tests/Commands/PlanCreateFromSessionTests.cs
@@ -54,4 +54,109 @@ public class PlanCreateFromSessionTests
         }
         finally { try { Directory.Delete(tmp, true); } catch { } }
     }
+
+    [Fact]
+    public async Task Plan_Create_FromSession_Json_Includes_TokenUsageApprox()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), "codepunk-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CODEPUNK_CONFIG_HOME", tmp);
+        Directory.CreateDirectory(tmp);
+        var testConsole = new TestConsole();
+        testConsole.Profile.Width = 5000;
+        var builder = Host.CreateApplicationBuilder(Array.Empty<string>());
+        builder.Services.AddCodePunkServices(builder.Configuration);
+        builder.Services.AddCodePunkConsole();
+        builder.Services.AddSingleton<IAnsiConsole>(sp => testConsole);
+
+        // design summary with multiple files to exercise char math
+        var fakeSummary = new SessionSummary
+        {
+            Goal = "Implement caching layer",
+            CandidateFiles = new List<string> { "src/Cache/MemoryCache.cs", "src/Cache/ICache.cs" },
+            Rationale = "Speed up repeated lookups",
+            Truncated = false,
+            UsedMessages = 5,
+            TotalMessages = 5
+        };
+        var summMock = new Mock<ISessionSummarizer>();
+        summMock.Setup(s => s.SummarizeAsync(It.IsAny<string>(), It.IsAny<SessionSummaryOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(fakeSummary);
+        builder.Services.AddSingleton<ISessionSummarizer>(summMock.Object);
+
+        var host = builder.Build();
+        var root = RootCommandFactory.Create(host.Services);
+
+        try
+        {
+            var code = await root.InvokeAsync(new[] { "plan", "create", "--from-session", "--json" });
+            Assert.Equal(0, code);
+            var text = testConsole.Output;
+            text = System.Text.RegularExpressions.Regex.Replace(text, "\u001B\\[[0-9;]*[A-Za-z]", string.Empty);
+            var doc = JsonDocument.Parse(text.Trim());
+            var rootEl = doc.RootElement;
+            var tu = rootEl.GetProperty("tokenUsageApprox");
+            var sampleChars = tu.GetProperty("sampleChars").GetInt32();
+            var approxTokens = tu.GetProperty("approxTokens").GetInt32();
+            // recompute expected sampleChars
+            var expectedSampleChars = (fakeSummary.Goal!.Length) + (fakeSummary.Rationale!.Length) + fakeSummary.CandidateFiles.Sum(f => f.Length + 1);
+            Assert.Equal(expectedSampleChars, sampleChars);
+            Assert.Equal(expectedSampleChars / 4, approxTokens);
+        }
+        finally { try { Directory.Delete(tmp, true); } catch { } }
+    }
+
+    [Fact]
+    public async Task Plan_Create_FromSession_Persists_Summary_With_TokenUsage()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), "codepunk-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CODEPUNK_CONFIG_HOME", tmp);
+        Directory.CreateDirectory(tmp);
+        var testConsole = new TestConsole();
+        testConsole.Profile.Width = 5000;
+        var builder = Host.CreateApplicationBuilder(Array.Empty<string>());
+        builder.Services.AddCodePunkServices(builder.Configuration);
+        builder.Services.AddCodePunkConsole();
+        builder.Services.AddSingleton<IAnsiConsole>(sp => testConsole);
+
+        var fakeSummary = new SessionSummary
+        {
+            Goal = "Refactor auth module",
+            CandidateFiles = new List<string> { "src/Auth/AuthService.cs" },
+            Rationale = "Improve testability",
+            Truncated = false,
+            UsedMessages = 7,
+            TotalMessages = 7
+        };
+        var summMock = new Mock<ISessionSummarizer>();
+        summMock.Setup(s => s.SummarizeAsync(It.IsAny<string>(), It.IsAny<SessionSummaryOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(fakeSummary);
+        builder.Services.AddSingleton<ISessionSummarizer>(summMock.Object);
+
+        var host = builder.Build();
+        var root = RootCommandFactory.Create(host.Services);
+        string planId = string.Empty;
+        try
+        {
+            var code = await root.InvokeAsync(new[] { "plan", "create", "--from-session", "--json" });
+            Assert.Equal(0, code);
+            var text = testConsole.Output;
+            text = System.Text.RegularExpressions.Regex.Replace(text, "\u001B\\[[0-9;]*[A-Za-z]", string.Empty);
+            var doc = JsonDocument.Parse(text.Trim());
+            planId = doc.RootElement.GetProperty("planId").GetString()!;
+            var store = host.Services.GetRequiredService<CodePunk.Console.Stores.IPlanFileStore>();
+            var rec = await store.GetAsync(planId);
+            Assert.NotNull(rec);
+            Assert.NotNull(rec!.Summary);
+            Assert.Equal("session", rec.Summary!.Source);
+            Assert.Equal(fakeSummary.Goal, rec.Summary.Goal);
+            Assert.Single(rec.Summary.CandidateFiles);
+            Assert.Equal(fakeSummary.CandidateFiles[0], rec.Summary.CandidateFiles[0]);
+            Assert.Equal(fakeSummary.Rationale, rec.Summary.Rationale);
+            Assert.Equal(fakeSummary.UsedMessages, rec.Summary.UsedMessages);
+            Assert.Equal(fakeSummary.TotalMessages, rec.Summary.TotalMessages);
+            Assert.NotNull(rec.Summary.TokenUsage);
+            var expectedSampleChars = (fakeSummary.Goal!.Length) + (fakeSummary.Rationale!.Length) + fakeSummary.CandidateFiles.Sum(f => f.Length + 1);
+            Assert.Equal(expectedSampleChars, rec.Summary.TokenUsage!.SampleChars);
+            Assert.Equal(expectedSampleChars / 4, rec.Summary.TokenUsage.ApproxTokens);
+        }
+        finally { try { Directory.Delete(tmp, true); } catch { } }
+    }
 }


### PR DESCRIPTION
## Summary
Implements Phase 1 of session-driven plan creation. When using `plan create --from-session`, the CLI now:
- Persists a `summary` block (`PlanSummary`) inside the plan file.
- Emits an additional `tokenUsageApprox` object in JSON output.
- Provides structured metadata for downstream tooling (goal, candidate files, rationale, message counts, truncation, token usage heuristic).

## Key Changes
- Added models: `PlanSummary`, `TokenUsageApprox`; extended `PlanRecord`.
- Updated `PlanCommandModule` to attach `PlanSummary` after plan creation in from-session path.
- Added heuristic token usage calculation (char/4) stored and surfaced as `tokenUsageApprox`.
- Adjusted `HeuristicSessionSummarizer` return to `Task<SessionSummary?>` (nullable) to allow graceful failure.
- Updated docs: `PARITY_PLAN.md` → v1.2.3 with Phase 1 completion; `SPEC_PLAN_FROM_SESSION.md` documents new output and persisted summary.
- Added/tests covering JSON enrichment, persistence, and backward compatibility.

## JSON Output Additions (`plan.create.fromSession.v1`)
```jsonc
{
  "schema": "plan.create.fromSession.v1",
  "planId": "...",
  "goal": "...",
  "candidateFiles": ["..."],
  "messageSampleCount": 5,
  "truncated": false,
  "tokenUsageApprox": {
    "sampleChars": 312,
    "approxTokens": 78
  }
}
```

## Persisted Plan File (New `summary` Section)
```jsonc
{
  "definition": { "id": "...", "goal": "...", "createdUtc": "..." },
  "files": [ /* unchanged */ ],
  "summary": {
    "source": "session",
    "goal": "...",
    "candidateFiles": [ "..."],
    "rationale": "...",
    "usedMessages": 5,
    "totalMessages": 5,
    "truncated": false,
    "tokenUsage": { "sampleChars": 312, "approxTokens": 78 }
  }
}
```

## Backward Compatibility
- Legacy plan JSON without `summary` continues to deserialize with `Summary == null`.
- Two tests validate: hand-crafted legacy file + rewrite of a newly created plan.

## Testing
- Added: `Plan_Create_FromSession_Json_Includes_TokenUsageApprox`
- Added: `Plan_Create_FromSession_Persists_Summary_With_TokenUsage`
- Added: Backward compatibility tests (two variants).
- All existing tests pass; no breaking schema changes.

## Rationale
Provides structured, inspectable provenance for plans created from session context and prepares groundwork for future AI-assisted multi-file plan generation (Phase 2) without altering existing schemas.

## Token Usage Heuristic
```
sampleChars = goal.Length + rationale.Length + Σ(filePath.Length + 1)
approxTokens = sampleChars / 4
```

## Docs & Version
- `PARITY_PLAN.md` bumped to v1.2.3, noting Phase 1 completion.
- `SPEC_PLAN_FROM_SESSION.md` updated with `tokenUsageApprox` and persisted summary details.

## Follow-Up (Out of Scope Here)
- Phase 2: AI model-assisted multi-file plan generation.
- Potential inclusion of `rationale` directly in JSON output (currently stored, not emitted).
- Unified token usage abstraction across commands once plan generation uses models.

## Release Notes (v1.2.3)
- Added: Session-driven plan creation now persists `PlanSummary` metadata (goal, candidate files, rationale, message counts, truncation, token usage heuristic).
- Added: `tokenUsageApprox` field in `plan.create.fromSession.v1` JSON.
- Changed: Heuristic summarizer returns nullable summary (graceful failure paths).
- Added: Backward compatibility tests for legacy plan files without summary.
- Docs: Updated parity plan and `SPEC_PLAN_FROM_SESSION.md`.

## Checklist
- [x] Code changes
- [x] Tests (persistence, JSON enrichment, backward compat)
- [x] Docs updated
- [x] Branch pushed (`feature/plan-summary-token-usage`)
- [ ] Merge & tag v1.2.3 post-review
